### PR TITLE
Rs workspace buttons

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,10 +19,11 @@ const App: React.FC<{}> = () => {
   });
 
   const [token, setToken] = useState<string>("");
-  const [workspaceData, setWorkspaceData] = useState<JSON>();
+  const [workspaceData, setWorkspaceData] = useState<string>("");
 
-  const testFunction = (data: JSON | undefined) => {
-    setWorkspaceData(data);
+  const testFunction = (data: any) => {
+    console.log(data[0].id);
+    setWorkspaceData(data[0].id);
   };
 
   return (

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -21,7 +21,7 @@ const App: React.FC<{}> = () => {
   const [token, setToken] = useState<string>("");
   const [workspaceData, setWorkspaceData] = useState<string>("");
 
-  const testFunction = (data: any) => {
+  const getTeamIdFromObject = (data: any) => {
     console.log(data[0].id);
     setWorkspaceData(data[0].id);
   };
@@ -32,8 +32,8 @@ const App: React.FC<{}> = () => {
         <Route path="/" index element={<Layout />}></Route>
         <Route path="/oauth" element={<OAuthClickUp />}></Route>
         <Route path="/oauth/success" element={<OAuthClickUp />}></Route>
-        <Route path="/automations" element={<Automations firstProp={workspaceData} />}></Route>
-        <Route path="/workspace/:token" element={<Workspace firstProp={testFunction} />}></Route>
+        <Route path="/automations" element={<Automations teamId={workspaceData} />}></Route>
+        <Route path="/workspace/:token" element={<Workspace teamCallback={getTeamIdFromObject} />}></Route>
       </Routes>
     </BrowserRouter>
   );

--- a/client/src/components/Automations/automations.tsx
+++ b/client/src/components/Automations/automations.tsx
@@ -10,7 +10,7 @@ const Automations = (props: AutomationPropList) => {
   const [bearer, setBearer] = useState('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InNiVkFxWkNGdVJBPSJ9.eyJ1c2VyIjoxNDkxNzI4NywidmFsaWRhdGVkIjp0cnVlLCJzZXNzaW9uX3Rva2VuIjp0cnVlLCJ3c19rZXkiOjI2MTQ1NTczOTMsImlhdCI6MTcwNTIwODYzMSwiZXhwIjoxNzA1MzgxNDMxfQ.9hnFChSCVfuVSLhxQUtpZrkTH1z_svLbGJMmjYfcPoU');
   const [shard, setShard] = useState('prod-us-east-2-1');
 
-  const [workspaceID, setWorkspaceID] = useState<string>("");
+  const [workspaceID, setWorkspaceID] = useState<string>(props.firstProp);
   const [spaceIDs, setSpaceIDs] = useState([16903372]);
   const [folderIDs, setFolderIDs] = useState([90111363530]);
   const [listIDs, setListIDs] = useState([192288379]);
@@ -23,13 +23,15 @@ const Automations = (props: AutomationPropList) => {
       'shard'
     ) as HTMLOutputElement;
     console.log(props.firstProp)
-    setWorkspaceID(props.firstProp)
-    const res = await axios.post('http://localhost:3001/automation/shard', {
-        teamId: props.firstProp
-    });
-    const shard = res.data;
-    printValue.textContent = shard;
-    setShard(shard);
+    console.log(workspaceID)
+    if(workspaceID.length > 1) {
+      const res = await axios.post('http://localhost:3001/automation/shard', {
+          teamId: workspaceID
+      });
+      const shard = res.data;
+      printValue.textContent = shard;
+      setShard(shard);
+    }
 
     // with workspace ID and shard:
     // get Spaces
@@ -97,7 +99,9 @@ const Automations = (props: AutomationPropList) => {
 
   useEffect(() => {
     console.log(props.firstProp)
-    if(props.firstProp !== undefined || props.firstProp !== "") {
+    if(workspaceID !== undefined) {
+      console.log(props.firstProp);
+      console.log(workspaceID);
       printShard();
     }
   },[props.firstProp])

--- a/client/src/components/Automations/automations.tsx
+++ b/client/src/components/Automations/automations.tsx
@@ -8,7 +8,7 @@ type AutomationPropList = {
 
 const Automations = (props: AutomationPropList) => {
   const [bearer, setBearer] = useState('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InNiVkFxWkNGdVJBPSJ9.eyJ1c2VyIjoxNDkxNzI4NywidmFsaWRhdGVkIjp0cnVlLCJzZXNzaW9uX3Rva2VuIjp0cnVlLCJ3c19rZXkiOjI2MTQ1NTczOTMsImlhdCI6MTcwNTIwODYzMSwiZXhwIjoxNzA1MzgxNDMxfQ.9hnFChSCVfuVSLhxQUtpZrkTH1z_svLbGJMmjYfcPoU');
-  const [shard, setShard] = useState('prod-us-east-2-1');
+  const [shard, setShard] = useState<string>('');
 
   const [workspaceID, setWorkspaceID] = useState<string>(props.firstProp);
   const [spaceIDs, setSpaceIDs] = useState([16903372]);
@@ -22,8 +22,6 @@ const Automations = (props: AutomationPropList) => {
     const printValue = document.getElementById(
       'shard'
     ) as HTMLOutputElement;
-    console.log(props.firstProp)
-    console.log(workspaceID)
     if(workspaceID.length > 1) {
       const res = await axios.post('http://localhost:3001/automation/shard', {
           teamId: workspaceID
@@ -98,13 +96,8 @@ const Automations = (props: AutomationPropList) => {
   };
 
   useEffect(() => {
-    console.log(props.firstProp)
-    if(workspaceID !== undefined) {
-      console.log(props.firstProp);
-      console.log(workspaceID);
       printShard();
-    }
-  },[props.firstProp])
+  },[])
 
   return (
     <div className="automations-container">

--- a/client/src/components/Automations/automations.tsx
+++ b/client/src/components/Automations/automations.tsx
@@ -3,37 +3,38 @@ import axios from "axios";
 import "./style.css";
 
 type AutomationPropList = {
-  firstProp: JSON | undefined
+  firstProp: string
 }
 
 const Automations = (props: AutomationPropList) => {
   const [bearer, setBearer] = useState('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InNiVkFxWkNGdVJBPSJ9.eyJ1c2VyIjoxNDkxNzI4NywidmFsaWRhdGVkIjp0cnVlLCJzZXNzaW9uX3Rva2VuIjp0cnVlLCJ3c19rZXkiOjI2MTQ1NTczOTMsImlhdCI6MTcwNTIwODYzMSwiZXhwIjoxNzA1MzgxNDMxfQ.9hnFChSCVfuVSLhxQUtpZrkTH1z_svLbGJMmjYfcPoU');
   const [shard, setShard] = useState('prod-us-east-2-1');
 
-  const [workspaceID, setWorkspaceID] = useState('10618731');
+  const [workspaceID, setWorkspaceID] = useState<string>("");
   const [spaceIDs, setSpaceIDs] = useState([16903372]);
   const [folderIDs, setFolderIDs] = useState([90111363530]);
   const [listIDs, setListIDs] = useState([192288379]);
+  // const [triggerId, setTriggerId] = useState<string>();
 
   let triggerIDArray;
 
   const printShard = async () => {
-    const workspaceId = document.getElementById(
-      'workspaceId-input'
-    ) as HTMLInputElement;
     const printValue = document.getElementById(
       'shard'
     ) as HTMLOutputElement;
-    const workspaceInput = workspaceId.value;
-    setWorkspaceID(workspaceInput)
-    
+    console.log(props.firstProp)
+    setWorkspaceID(props.firstProp)
     const res = await axios.post('http://localhost:3001/automation/shard', {
         teamId: props.firstProp
     });
     const shard = res.data;
-    console.log('from Automations page', props.firstProp)
     printValue.textContent = shard;
     setShard(shard);
+
+    // with workspace ID and shard:
+    // get Spaces
+    // for each Space, get Folders, get Folderless lists
+    // for each Folder, get lists
   };
 
   function printBearer(): void {
@@ -81,18 +82,31 @@ const Automations = (props: AutomationPropList) => {
     });
   };
 
+  const findAutomation = () => {
+    // use functions above to find automation by trigger_id
+    const trigger = document.getElementById(
+      'trigger-input'
+    ) as HTMLInputElement;
+    const triggerInput = trigger.value;
+    const printValue = document.getElementById(
+      'trigger-output'
+    ) as HTMLOutputElement;
+    printValue.textContent = triggerInput.toString();
+    // setTriggerId(triggerInput);
+  };
+
   useEffect(() => {
-    if(props.firstProp !== undefined) {
+    console.log(props.firstProp)
+    if(props.firstProp !== undefined || props.firstProp !== "") {
       printShard();
     }
-    // console.log(yourTeamData)
-    // get Spaces
-    // for each Space, get Folders, get Folderless lists
-    // for each Folder, get lists
-  }, [props.firstProp])
+  },[props.firstProp])
 
   return (
     <div className="automations-container">
+      <h3>
+        Your shard is: <output id="shard"></output>
+      </h3>
       <h1>The automations page</h1>
       <span>Enter a bearer token</span>
       <br />
@@ -100,17 +114,21 @@ const Automations = (props: AutomationPropList) => {
       <input type="text" id="bearer-input" placeholder="bearer" />
       <br />
       <button onClick={() => printBearer()}>Print</button>
-      <h3>
+      <h4>
         Your bearer token is: <output id="enteredNumber"></output>
-      </h3>
+      </h4>
 
-      <input type="text" id="workspaceId-input" placeholder="workspaceId" />
+      <span>Enter a trigger_id</span>
       <br />
-      <button onClick={() => printShard()}>Print Shard</button>
-      <h3>
-        Your shard is: <output id="shard"></output>
-      </h3>
-
+      <input type="text" id="trigger-input" placeholder="triggerId" />
+      <br />
+      <button onClick={() => findAutomation()}>Find Automation</button>
+      <h4>
+        Your trigger_id: <output id="trigger-output"></output>
+      </h4>
+      <h4>
+        Your Automation is: <output id="automation"></output>
+      </h4>
     </div>
   );
 };

--- a/client/src/components/Automations/automations.tsx
+++ b/client/src/components/Automations/automations.tsx
@@ -1,30 +1,34 @@
-import React, { useEffect, useState } from "react";
-import axios from "axios";
-import "./style.css";
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import './style.css';
 
 type AutomationPropList = {
-  firstProp: string
-}
+  teamId: string;
+};
 
 const Automations = (props: AutomationPropList) => {
-  const [bearer, setBearer] = useState('eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCIsImtpZCI6InNiVkFxWkNGdVJBPSJ9.eyJ1c2VyIjoxNDkxNzI4NywidmFsaWRhdGVkIjp0cnVlLCJzZXNzaW9uX3Rva2VuIjp0cnVlLCJ3c19rZXkiOjI2MTQ1NTczOTMsImlhdCI6MTcwNTIwODYzMSwiZXhwIjoxNzA1MzgxNDMxfQ.9hnFChSCVfuVSLhxQUtpZrkTH1z_svLbGJMmjYfcPoU');
-  const [shard, setShard] = useState<string>('');
+  // inputs - manual
+  const [bearer, setBearer] = useState<string>('');
+  const [triggerId, setTriggerId] = useState<string>('');
 
-  const [workspaceID, setWorkspaceID] = useState<string>(props.firstProp);
+  // passed from workspace.tsx - done
+  const [workspaceID, setWorkspaceID] = useState<string>(props.teamId);
+  // sets dynamically by workspaceID on page load
+  const [shard, setShard] = useState<string>('');
+  
+  // still need these, temporary placeholders - in progress
   const [spaceIDs, setSpaceIDs] = useState([16903372]);
   const [folderIDs, setFolderIDs] = useState([90111363530]);
   const [listIDs, setListIDs] = useState([192288379]);
-  // const [triggerId, setTriggerId] = useState<string>();
 
+  // to store all triggerIds from all spaces, folders, lists
   let triggerIDArray;
 
-  const printShard = async () => {
-    const printValue = document.getElementById(
-      'shard'
-    ) as HTMLOutputElement;
-    if(workspaceID.length > 1) {
+  const printShardFromWorkspaceId = async () => {
+    const printValue = document.getElementById('shard') as HTMLOutputElement;
+    if (workspaceID.length > 1) {
       const res = await axios.post('http://localhost:3001/automation/shard', {
-          teamId: workspaceID
+        teamId: workspaceID,
       });
       const shard = res.data;
       printValue.textContent = shard;
@@ -36,18 +40,6 @@ const Automations = (props: AutomationPropList) => {
     // for each Space, get Folders, get Folderless lists
     // for each Folder, get lists
   };
-
-  function printBearer(): void {
-    const bearerValue = document.getElementById(
-      'bearer-input'
-    ) as HTMLInputElement;
-    const printValue = document.getElementById(
-      'enteredNumber'
-    ) as HTMLOutputElement;
-    const bearerInput = bearerValue.value;
-    printValue.textContent = bearerInput.toString();
-    setBearer(bearerInput);
-  }
 
   const getListAutomations = (listIDs: number[]) => {
     listIDs.forEach((id) => {
@@ -82,7 +74,19 @@ const Automations = (props: AutomationPropList) => {
     });
   };
 
-  const findAutomation = () => {
+  function printBearer(): void {
+    const bearerValue = document.getElementById(
+      'bearer-input'
+    ) as HTMLInputElement;
+    const printValue = document.getElementById(
+      'enteredNumber'
+    ) as HTMLOutputElement;
+    const bearerInput = bearerValue.value;
+    printValue.textContent = bearerInput.toString();
+    setBearer(bearerInput);
+  }
+
+  const printTriggerId = () => {
     // use functions above to find automation by trigger_id
     const trigger = document.getElementById(
       'trigger-input'
@@ -92,12 +96,26 @@ const Automations = (props: AutomationPropList) => {
       'trigger-output'
     ) as HTMLOutputElement;
     printValue.textContent = triggerInput.toString();
-    // setTriggerId(triggerInput);
+    setTriggerId(triggerInput);
   };
 
   useEffect(() => {
-      printShard();
-  },[])
+    printShardFromWorkspaceId();
+  }, []);
+
+  // useEffects for what this component has
+  useEffect(() => {
+    console.log(`workspaceID being searched: ${workspaceID}`);
+  }, [workspaceID]);
+  useEffect(() => {
+    console.log(`workspace shard: ${shard}`);
+  }, [shard]);
+  useEffect(() => {
+    console.log(`triggerID being searched: ${triggerId}`);
+  }, [triggerId]);
+  useEffect(() => {
+    console.log(`bearer token for ?workflow endpoint: ${bearer}`);
+  }, [bearer]);
 
   return (
     <div className="automations-container">
@@ -119,12 +137,12 @@ const Automations = (props: AutomationPropList) => {
       <br />
       <input type="text" id="trigger-input" placeholder="triggerId" />
       <br />
-      <button onClick={() => findAutomation()}>Find Automation</button>
+      <button onClick={() => printTriggerId()}>Find Automation</button>
       <h4>
         Your trigger_id: <output id="trigger-output"></output>
       </h4>
       <h4>
-        Your Automation is: <output id="automation"></output>
+        Your Automation is: <output id="automation">placeholder</output>
       </h4>
     </div>
   );

--- a/client/src/components/Automations/automations.tsx
+++ b/client/src/components/Automations/automations.tsx
@@ -82,12 +82,14 @@ const Automations = (props: AutomationPropList) => {
   };
 
   useEffect(() => {
-    printShard();
+    if(props.firstProp !== undefined) {
+      printShard();
+    }
     // console.log(yourTeamData)
     // get Spaces
     // for each Space, get Folders, get Folderless lists
     // for each Folder, get lists
-  })
+  }, [props.firstProp])
 
   return (
     <div className="automations-container">

--- a/client/src/components/workspace.tsx
+++ b/client/src/components/workspace.tsx
@@ -7,20 +7,11 @@ type workspacePropList = {
   firstProp: (a: JSON | undefined) => void;
 };
 
-type WrapperProps = {
-  children: JSX.Element;
-};
-
-function Wrapper (props: WrapperProps) {
-  return <div>{props.children}</div>;
-};
-
 export default function Workspace({ firstProp }: workspacePropList) {
   let { token } = useParams();
   const navigate = useNavigate();
   const [teamData, setTeamData] = useState<JSON>();
   const [teamArray, setTeamArray] = useState<Object[]>();
-
 
   const GetTeams = async (): Promise<void> => {
     await axios
@@ -36,18 +27,21 @@ export default function Workspace({ firstProp }: workspacePropList) {
       });
   };
 
-  const listButtons = (data: any) => {
+  const createButtons = (data: any) => {
     if (data !== undefined) {
       let jsonData = JSON.parse(data);
       let teamArr = jsonData.teams;
-      setTeamArray(teamArr);
-      console.log(teamArr);
+
+      const teamNames = teamArr.map((team: any, index: number) => {
+        return team.name;
+      });
+      setTeamArray(teamNames);
     }
   };
 
   useEffect(() => {
     if (teamData !== undefined) {
-      listButtons(teamData);
+      createButtons(teamData);
       firstProp(teamData);
     }
   }, [teamData]);
@@ -58,18 +52,25 @@ export default function Workspace({ firstProp }: workspacePropList) {
 
   return (
     <Container>
-      <>
-      {teamArray?.forEach((team: object) => {
-        console.log(team)
-      })}
-      <Button
-        onClick={() => {
-          navigate('/automations');
-        }}
-      >
-        Automations
-      </Button>
-      </>
+      <table>
+        <tbody>
+          <th>Click Workspace to find Automation</th>
+          {teamArray?.map((team: any, i: number) => (
+            <tr>
+              <td>
+                <Button
+                  key={i}
+                  onClick={() => {
+                    navigate('/automations');
+                  }}
+                >
+                  {`${team}`}
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </Container>
   );
 }

--- a/client/src/components/workspace.tsx
+++ b/client/src/components/workspace.tsx
@@ -51,6 +51,7 @@ export default function Workspace({ firstProp }: workspacePropList) {
       });
       console.log(teamObject)
       firstProp(teamObject);
+      navigate('/automations');
     }
   };
 
@@ -80,7 +81,6 @@ export default function Workspace({ firstProp }: workspacePropList) {
                   key={i}
                   onClick={() => {
                     setClickedTeam(team);
-                    // navigate('/automations');
                   }}
                 >
                   {`${team}`}

--- a/client/src/components/workspace.tsx
+++ b/client/src/components/workspace.tsx
@@ -1,16 +1,26 @@
-import { useEffect, useState } from "react";
-import axios from "axios";
-import { Button, Container, Col } from "react-bootstrap";
-import { useNavigate, useParams } from "react-router-dom";
+import { useEffect, useState } from 'react';
+import axios from 'axios';
+import { Button, Container, Col, ContainerProps } from 'react-bootstrap';
+import { useNavigate, useParams } from 'react-router-dom';
 
 type workspacePropList = {
-  firstProp: (a: JSON | undefined) => void
-}
+  firstProp: (a: JSON | undefined) => void;
+};
+
+type WrapperProps = {
+  children: JSX.Element;
+};
+
+function Wrapper (props: WrapperProps) {
+  return <div>{props.children}</div>;
+};
 
 export default function Workspace({ firstProp }: workspacePropList) {
   let { token } = useParams();
   const navigate = useNavigate();
   const [teamData, setTeamData] = useState<JSON>();
+  const [teamArray, setTeamArray] = useState<Object[]>();
+
 
   const GetTeams = async (): Promise<void> => {
     await axios
@@ -18,30 +28,48 @@ export default function Workspace({ firstProp }: workspacePropList) {
         token: token,
       })
       .then((resp) => {
-        setTeamData(resp.data)})
+        setTeamData(resp.data);
+        console.log(resp.data);
+      })
       .catch((error) => {
         console.log(error);
       });
   };
 
   const listButtons = (data: any) => {
-    console.log('list function', typeof data);
-  }
-    
+    if (data !== undefined) {
+      let jsonData = JSON.parse(data);
+      let teamArr = jsonData.teams;
+      setTeamArray(teamArr);
+      console.log(teamArr);
+    }
+  };
+
   useEffect(() => {
-    listButtons(teamData)
-    firstProp(teamData)
-  }, [teamData])
+    if (teamData !== undefined) {
+      listButtons(teamData);
+      firstProp(teamData);
+    }
+  }, [teamData]);
 
   useEffect(() => {
     GetTeams();
   }, []);
 
-  return <Container>{JSON.stringify(teamData)}
-  <Button
-  onClick={() => {
-    navigate('/automations');
-  }}
-  >Automations</Button>
-  </Container>;
+  return (
+    <Container>
+      <>
+      {teamArray?.forEach((team: object) => {
+        console.log(team)
+      })}
+      <Button
+        onClick={() => {
+          navigate('/automations');
+        }}
+      >
+        Automations
+      </Button>
+      </>
+    </Container>
+  );
 }

--- a/client/src/components/workspace.tsx
+++ b/client/src/components/workspace.tsx
@@ -4,10 +4,10 @@ import { Button, Container, Col, ContainerProps } from 'react-bootstrap';
 import { useNavigate, useParams } from 'react-router-dom';
 
 type workspacePropList = {
-  firstProp: (a: string) => void;
+  teamCallback: (a: string) => void;
 };
 
-export default function Workspace({ firstProp }: workspacePropList) {
+export default function Workspace({ teamCallback }: workspacePropList) {
   let { token } = useParams();
   const navigate = useNavigate();
   const [teamData, setTeamData] = useState<JSON>();
@@ -49,7 +49,7 @@ export default function Workspace({ firstProp }: workspacePropList) {
           return team;
         };
       });
-      firstProp(teamObject);
+      teamCallback(teamObject);
       navigate('/automations');
     }
   };

--- a/client/src/components/workspace.tsx
+++ b/client/src/components/workspace.tsx
@@ -4,7 +4,7 @@ import { Button, Container, Col, ContainerProps } from 'react-bootstrap';
 import { useNavigate, useParams } from 'react-router-dom';
 
 type workspacePropList = {
-  firstProp: (a: JSON | undefined) => void;
+  firstProp: (a: string) => void;
 };
 
 export default function Workspace({ firstProp }: workspacePropList) {
@@ -12,6 +12,7 @@ export default function Workspace({ firstProp }: workspacePropList) {
   const navigate = useNavigate();
   const [teamData, setTeamData] = useState<JSON>();
   const [teamArray, setTeamArray] = useState<Object[]>();
+  const [clickedTeam, setClickedTeam] = useState<JSON>();
 
   const GetTeams = async (): Promise<void> => {
     await axios
@@ -39,10 +40,27 @@ export default function Workspace({ firstProp }: workspacePropList) {
     }
   };
 
+  const sendTeam = (data: any) => {
+    if(data !== undefined) {
+      const jsonData = JSON.parse(data);
+      const teamArr = (jsonData.teams);
+      const teamObject = teamArr.filter((team: any, i: number) => {
+        if(team.name === clickedTeam) {
+          return team;
+        };
+      });
+      console.log(teamObject)
+      firstProp(teamObject);
+    }
+  };
+
+  useEffect(()=> {
+    sendTeam(teamData);
+  }, [clickedTeam]);
+
   useEffect(() => {
     if (teamData !== undefined) {
       createButtons(teamData);
-      firstProp(teamData);
     }
   }, [teamData]);
 
@@ -56,12 +74,13 @@ export default function Workspace({ firstProp }: workspacePropList) {
         <tbody>
           <th>Click Workspace to find Automation</th>
           {teamArray?.map((team: any, i: number) => (
-            <tr>
-              <td>
+            <tr key={i}>
+              <td key={i}>
                 <Button
                   key={i}
                   onClick={() => {
-                    navigate('/automations');
+                    setClickedTeam(team);
+                    // navigate('/automations');
                   }}
                 >
                   {`${team}`}

--- a/client/src/components/workspace.tsx
+++ b/client/src/components/workspace.tsx
@@ -33,7 +33,7 @@ export default function Workspace({ firstProp }: workspacePropList) {
       let jsonData = JSON.parse(data);
       let teamArr = jsonData.teams;
 
-      const teamNames = teamArr.map((team: any, index: number) => {
+      const teamNames = teamArr.map((team: any) => {
         return team.name;
       });
       setTeamArray(teamNames);
@@ -44,12 +44,11 @@ export default function Workspace({ firstProp }: workspacePropList) {
     if(data !== undefined) {
       const jsonData = JSON.parse(data);
       const teamArr = (jsonData.teams);
-      const teamObject = teamArr.filter((team: any, i: number) => {
+      const teamObject = teamArr.filter((team: any) => {
         if(team.name === clickedTeam) {
           return team;
         };
       });
-      console.log(teamObject)
       firstProp(teamObject);
       navigate('/automations');
     }

--- a/server/src/routes/AutomationRoutes.ts
+++ b/server/src/routes/AutomationRoutes.ts
@@ -6,8 +6,6 @@ AutomationRoutes.post(
   '/shard',
   async (req: Request, res: Response): Promise<any> => {
     const teamId = req.body.teamId;
-    console.log('BE', req.body.teamId);
-
     try {
       const response = await fetch(
         `https://app.clickup.com/shard/v1/handshake/${teamId}`,

--- a/server/src/routes/AutomationRoutes.ts
+++ b/server/src/routes/AutomationRoutes.ts
@@ -6,7 +6,7 @@ AutomationRoutes.post(
   '/shard',
   async (req: Request, res: Response): Promise<any> => {
     const teamId = req.body.teamId;
-    console.log(req.body.teamId);
+    console.log('BE', req.body.teamId);
 
     try {
       const response = await fetch(


### PR DESCRIPTION
this accounts for multiple workspaces connected through OAuth, each workspace is represented by a button that you click to navigate to the automation finder for that workspace.

right now, on page load the automation finder uses the selected workspaceId to find that workspaces shard and print. We need this for the workflow calls. Also needed:
1. a bearer token - different from the token we get from OAuth, it needs to be manually input and we have an input field for it!
2. location Ids:

SpaceID's, FolderID's, ListID's -> using the workspaceID we can get these next