### PR TITLE
modified frontend requests to automatically generate arrays of data d…

### DIFF
--- a/client/src/components/workspace.tsx
+++ b/client/src/components/workspace.tsx
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
-import axios from 'axios';
-import { Button, Container, Col, ContainerProps } from 'react-bootstrap';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useEffect, useState } from "react";
+import axios from "axios";
+import { Button, Container, Col, ContainerProps, Row } from "react-bootstrap";
+import { useNavigate, useParams } from "react-router-dom";
+import { Space, Team } from "../models/workspace_interface";
 
 type workspacePropList = {
   teamCallback: (a: string) => void;
@@ -10,13 +11,94 @@ type workspacePropList = {
 export default function Workspace({ teamCallback }: workspacePropList) {
   let { token } = useParams();
   const navigate = useNavigate();
+  //containers for response object
   const [teamData, setTeamData] = useState<JSON>();
-  const [teamArray, setTeamArray] = useState<Object[]>();
+  const [spaceData, setSpaceData] = useState<JSON>();
+  const [folderData, setFolderData] = useState<JSON>();
+  const [folderlessListData, setFolderlessListData] = useState<JSON>();
+  const [listData, setListData] = useState<JSON>();
+  //containers for
+  const [teamArray, setTeamArray] = useState<Team[]>([]);
+  const [spaceArray, setSpaceArray] = useState<Space[]>([]);
+  const [folderArray, setFolderArray] = useState<Object[]>([]);
+  const [folderlessListArray, setFolderlessListArray] = useState<Object[]>([]);
+  const [listArray, setListArray] = useState<Object[]>();
+  //
   const [clickedTeam, setClickedTeam] = useState<JSON>();
 
   const GetTeams = async (): Promise<void> => {
     await axios
       .post(`http://localhost:3001/workspace/teams`, {
+        token: token,
+      })
+      .then((resp) => {
+        if (resp.data != undefined) {
+          let jsonData = JSON.parse(resp.data);
+          const teamsArrayData: Team[] = jsonData.teams;
+          const individualTeamObjects: Team[] = [];
+          for (const team of teamsArrayData) {
+            individualTeamObjects.push(team); // Add the team object to the new array
+          }
+          setSpaceArray([]);
+          setTeamArray(individualTeamObjects);
+        }
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  };
+
+  const GetSpaces = async (teamId: string): Promise<void> => {
+    await axios
+      .post(`http://localhost:3001/workspace/spaces`, {
+        token: token,
+        teamId: teamId,
+      })
+      .then((resp) => {
+        if (resp.data != undefined) {
+          let jsonData = JSON.parse(resp.data);
+          const spaceArrayData: Space[] = jsonData.spaces;
+          const indvidualArray: Space[] = [];
+          for (var i = 0; i < spaceArrayData.length; i++) {
+            indvidualArray.push(spaceArrayData[i]);
+          }
+          setSpaceArray((spaceArray) => [...spaceArray, ...indvidualArray]);
+        }
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  };
+
+  const GetFolders = async (data: any): Promise<void> => {
+    await axios
+      .post(`http://localhost:3001/workspace/folders`, {
+        token: token,
+      })
+      .then((resp) => {
+        setTeamData(resp.data);
+        console.log(resp.data);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  };
+  const GetFolderlessLists = async (data: any): Promise<void> => {
+    await axios
+      .post(`http://localhost:3001/workspace/folderless/lists`, {
+        token: token,
+      })
+      .then((resp) => {
+        setTeamData(resp.data);
+        console.log(resp.data);
+      })
+      .catch((error) => {
+        console.log(error);
+      });
+  };
+  const GetLists = async (data: any): Promise<void> => {
+    await axios
+      .post(`http://localhost:3001/workspace/lists`, {
         token: token,
       })
       .then((resp) => {
@@ -41,20 +123,20 @@ export default function Workspace({ teamCallback }: workspacePropList) {
   };
 
   const sendTeam = (data: any) => {
-    if(data !== undefined) {
+    if (data !== undefined) {
       const jsonData = JSON.parse(data);
-      const teamArr = (jsonData.teams);
+      const teamArr = jsonData.teams;
       const teamObject = teamArr.filter((team: any) => {
-        if(team.name === clickedTeam) {
+        if (team.name === clickedTeam) {
           return team;
-        };
+        }
       });
       teamCallback(teamObject);
-      navigate('/automations');
+      navigate("/automations");
     }
   };
 
-  useEffect(()=> {
+  useEffect(() => {
     sendTeam(teamData);
   }, [clickedTeam]);
 
@@ -68,9 +150,41 @@ export default function Workspace({ teamCallback }: workspacePropList) {
     GetTeams();
   }, []);
 
+  useEffect(() => {
+    if (teamArray!.length > 0) {
+      for (var i = 0; i < teamArray!.length; i++) {
+        GetSpaces(teamArray![i].id);
+      }
+    }
+  }, [teamArray]);
+
   return (
-    <Container>
-      <table>
+    <Container fluid>
+      <Row>
+        <Col xxl={6}>
+          {teamArray?.map((team: any, i: number) => (
+            <Button
+              key={i}
+              onClick={() => {
+                setClickedTeam(team);
+              }}>
+              {`${team.name} id: ${team.id}`}
+            </Button>
+          ))}
+        </Col>
+        <Col xxl={6}>
+          {spaceArray?.map((space: any, i: number) => (
+            <tr key={i}>
+              <td key={i}>
+                <Button key={i} onClick={() => {}}>
+                  {`${space.name} id: ${space.id}`}
+                </Button>
+              </td>
+            </tr>
+          ))}
+        </Col>
+      </Row>
+      {/* <table>
         <tbody>
           <th>Click Workspace to find Automation</th>
           {teamArray?.map((team: any, i: number) => (
@@ -80,15 +194,23 @@ export default function Workspace({ teamCallback }: workspacePropList) {
                   key={i}
                   onClick={() => {
                     setClickedTeam(team);
-                  }}
-                >
-                  {`${team}`}
+                  }}>
+                  {`${team.name} id: ${team.id}`}
+                </Button>
+              </td>
+            </tr>
+          ))}
+          {spaceArray?.map((space: any, i: number) => (
+            <tr key={i}>
+              <td key={i}>
+                <Button key={i} onClick={() => {}}>
+                  {`${space.name} id: ${space.id}`}
                 </Button>
               </td>
             </tr>
           ))}
         </tbody>
-      </table>
+      </table> */}
     </Container>
   );
 }

--- a/client/src/models/workspace_interface.tsx
+++ b/client/src/models/workspace_interface.tsx
@@ -1,0 +1,95 @@
+export interface Team {
+  id: string;
+  name: string;
+  color: string;
+  avatar: null | string;
+  members: Array<{
+    user: {
+      id: number;
+      username: string;
+      email: string;
+      color: string;
+      profilePicture: null | string;
+      initials: string;
+      role: number;
+      custom_role: null | string;
+      last_active: string;
+      date_joined: string;
+      date_invited: string;
+    };
+    invited_by: {
+      id: number;
+      username: string;
+      color: string;
+      email: string;
+      initials: string;
+      profilePicture: null | string;
+    };
+  }>;
+}
+
+export interface User {
+  id: string;
+  username: string;
+  color: null | string;
+  profilePicture: null | string;
+  initials: string;
+}
+
+export interface Status {
+  status: string;
+  type: string;
+  orderindex: number;
+  color: string;
+}
+
+export interface Features {
+  due_dates: {
+    enabled: boolean;
+    start_date: boolean;
+    remap_due_dates: boolean;
+    remap_closed_due_date: boolean;
+  };
+  time_tracking: {
+    enabled: boolean;
+  };
+  tags: {
+    enabled: boolean;
+  };
+  time_estimates: {
+    enabled: boolean;
+  };
+  checklists: {
+    enabled: boolean;
+  };
+  custom_fields: {
+    enabled: boolean;
+  };
+  remap_dependencies: {
+    enabled: boolean;
+  };
+  dependency_warning: {
+    enabled: boolean;
+  };
+  portfolios: {
+    enabled: boolean;
+  };
+}
+
+export interface Member {
+  user: User;
+}
+
+export interface Space {
+  id: string;
+  name: string;
+  private: boolean;
+  color: null | string;
+  avatar: null | string;
+  admin_can_manage: boolean;
+  archived: boolean;
+  members: Member[];
+  statuses: Status[];
+  multiple_assignees: boolean;
+  features: Features;
+}


### PR DESCRIPTION
As I was creating the front end requests to get team, space, folder, list, etc I realized that there were multiple functions required to get the raw data into an array we could present to the frontend.  So I plan to consolidate this all into a single function for each level of the hierarchy.  

The result is a function that gets the data, converts it to a JSON object, then extracts the data from the array of objects within.  From there we can just use dot notation to access each object's properties like name or ID and they'll always be paired together.  

Currently this all happens automatically so that all of the spaces in all of the workspaces, the outstanding issue I need to workout is how to attribute a given level of a hierarchy to its parent.  Like I now display all of the Spaces but there is no indication of what team each space belongs to.