### PR TITLE
localstorage.clear() implemennted on home

### DIFF
--- a/client/src/components/constants.tsx
+++ b/client/src/components/constants.tsx
@@ -1,0 +1,6 @@
+export const APIConstants = {
+    client_id: "BN5I81XZTDNWALCJDDMLJ5MOL50ZGCKS",
+    client_secret:
+      "O6ELNOPES1I547TTMRUOWDOZ4VUW38MQ0NRZ6RNQEUWNU3DEJDQCO5DR6F6L9F86",
+    redirect_uri: "http://localhost:3000/oauth/success",
+  };

--- a/client/src/models/socket.tsx
+++ b/client/src/models/socket.tsx
@@ -1,6 +1,6 @@
 export interface ServerToClientEvents {
   noArg: () => void;
-  basicEmit: (a: number, b: string, c: Buffer) => void;
+  basicEmit: (event: String) => void;
   withAck: (d: string, callback: (e: number) => void) => void;
 }
 

--- a/client/src/pages/Home.tsx
+++ b/client/src/pages/Home.tsx
@@ -1,8 +1,12 @@
 import React, { useEffect, useState } from 'react';
+import { APIConstants } from '../constants'; 
 
 export default function Home() {
+
   useEffect(() => {
-    localStorage.removeItem('token');
+    console.log('LocalStorage.clear() running...');
+    localStorage.clear();
+    console.log('LocalStorage cleared!');    
   }, []);
 
   return (

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import { Server } from "socket.io";
 import AutomationRoutes from "./routes/AutomationRoutes";
 import WorkspaceRoutes from "./routes/WorkspaceRoutes";
 import BasicAuth from "./routes/BasicAuthRoutes";
+import { URLSearchParams } from "url";
 export const routes = express.Router();
 
 const app = express();
@@ -47,7 +48,7 @@ interface SocketData {
 }
 // server-side
 io.on("connection", (socket: { id: any }) => {
-  console.log(socket.id); // x8WIv7-mJelg7on_ALbx
+  console.log(socket.id + " is connected"); // x8WIv7-mJelg7on_ALbx
 });
 
 app.use(
@@ -77,6 +78,24 @@ app.post("/token", async (req: Request, res: Response): Promise<any> => {
   console.log(data);
   res.send(data);
 });
+
+app.delete("/clear", async (req: Request, res: Response): Promise<any> => {
+  
+    const shard = req.body.shard;
+    const client_id = req.body.client_id;
+    const token = req.body.bearer;
+  
+
+  const resp = await fetch(
+    `https://${shard}.clickup.com/auth/v1/oauthClientAuth/${client_id}`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: `Bearer ${token}`,
+      }
+    }
+  )
+})
 
 routes.use(WorkspaceRoutes);
 routes.use(AutomationRoutes);


### PR DESCRIPTION
removed your localstorage.removeitem() function as clear() works better for this.  not sure why removeitem() didn't work honestly.

added a route at localhost:3000/clear to request clear of OAUTH connection from each connected Workspace that MUST be used on the Automations page I think.  still haven't implemented this yet but I think it's the only place to run it since each shard and workspace ID must be ran to clear the connection from each.  