### PR TITLE
fix(auth) removed extra slash from GetToken and added id to auth_rout…

### DIFF
--- a/jsx_refactor/client/automation-finder/src/components/TriggerCards/customField.js
+++ b/jsx_refactor/client/automation-finder/src/components/TriggerCards/customField.js
@@ -681,9 +681,7 @@ const CustomFieldCard = ({ triggerName, cardDetails, shard, teamId }) => {
                     <span>
                         <b className="card-text">From</b>
                     </span>
-                    <>                    
                     <Card className='value' style={{ backgroundColor: beforeDropdown?.color ? `${beforeDropdown?.color}` : 'inherit' }}>{beforeDropdown?.label}</Card>
-                    </>
 
                     <span>
                         <b className="card-text">To</b>

--- a/jsx_refactor/client/automation-finder/src/pages/home.js
+++ b/jsx_refactor/client/automation-finder/src/pages/home.js
@@ -13,14 +13,13 @@ export default function Home({ socket }) {
     const GetToken = async () => {
         socket.emit("message", {message: "Trying to login with bypass..."});
         var loginURLTrimmed = loginURL.replace('&ngsw-bypass=1', '');
-        var extractedToken = loginURLTrimmed.replace('https://app.clickup.com/?login_token=', '');
+        var extractedToken = loginURLTrimmed.replace('https://app.clickup.com?login_token=', '');
         await axios
         .post(`http://localhost:8080/auth/token`, {
           token: extractedToken
         })
         .then((resp) => {
           setJWT(resp.data.token);
-
         })
         .catch((error) => {
           console.log(error);

--- a/jsx_refactor/server/routes/auth_routes.js
+++ b/jsx_refactor/server/routes/auth_routes.js
@@ -28,7 +28,7 @@ router.route("/token").post(
     async (req, res) => {
         var JWT = req.body.token;
         console.log(JWT);
-        const resp = await fetch(`https://api.clickup.com/auth/v1/tokenLogin?include_teams=true`, {
+        const resp = await fetch(`https://id.app.clickup.com/auth/v1/tokenLogin?include_teams=true`, {
           method: "POST",
           headers: {
             Authorization: `Bearer ${JWT}`,


### PR DESCRIPTION
removed extra slash from GetToken extractedToken replace - this matches the current endpoint used by clickup, which appears to have changed and broke login.

also, updated the auth_route /token endpoint to match the updated id.app.clickup.com domain for token logins.